### PR TITLE
Extrapolate steam vanity

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -79,10 +79,7 @@ class UsersController < ApplicationController
             
             redirect_to user_path(user)
         else
-            @videogames = Videogame.all
-            @user = user
-            @videogame = videogame
-            render :add_new_game
+           redirect_to user_path(user)
         end
         
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,14 +21,16 @@ class User < ApplicationRecord
         extrapolate_steam_vanity
           if valid_steamID? 
             convert_steam_vanity_to_steamID
-            errors.add(:steam_url, 'Must be proper format') unless valid_steamID?
+            steam_url_error_message unless valid_steamID?
           end
       elsif id_url?
         if valid_steamID?
           extrapolate_steamID
         else
-          errors.add(:steam_url, 'Must be proper format')
+          steam_url_error_message
         end
+      else
+        steam_url_error_message
       end
     end
   end
@@ -61,6 +63,10 @@ class User < ApplicationRecord
   def valid_steamID?
     Steam.apikey = ENV["STEAM_API_KEY"]
     !Steam::User.summary(self.steam_id).nil?
+  end
+
+  def steam_url_error_message
+    errors.add(:steam_url, 'Invalid Steam Profile URL')
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,19 +18,17 @@ class User < ApplicationRecord
   def correct_steam_url
     if !(self.steam_url.nil?) && self.steam_id.nil? && self.steam_vanity.nil?
       if vanity_url?
+        begin
         extrapolate_steam_vanity
-          if valid_steamID? 
-            convert_steam_vanity_to_steamID
-            steam_url_error_message unless valid_steamID?
-          end
-      elsif id_url?
-        if valid_steamID?
-          extrapolate_steamID
-        else
-          steam_url_error_message
+        convert_steam_vanity_to_steamID
+        rescue Steam::SteamError 
         end
+        return steam_url_error_message unless valid_steamID?
+      elsif id_url?
+        extrapolate_steamID
+        return steam_url_error_message unless valid_steamID?
       else
-        steam_url_error_message
+        return steam_url_error_message
       end
     end
   end
@@ -52,6 +50,7 @@ class User < ApplicationRecord
   end
 
   def extrapolate_steam_vanity
+    Steam.apikey = ENV["STEAM_API_KEY"]
     self.steam_vanity = parsed_steam_url[4]
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,12 +23,12 @@ class User < ApplicationRecord
         convert_steam_vanity_to_steamID
         rescue Steam::SteamError 
         end
-        return steam_url_error_message unless valid_steamID?
+        steam_url_error_message unless valid_steamID?
       elsif id_url?
         extrapolate_steamID
-        errors.add(:steam_url, 'Invalid Steam Profile URL') unless valid_steamID?
+        steam_url_error_message unless valid_steamID?
       else
-        errors.add(:steam_url, 'Invalid Steam Profile URL')
+        steam_url_error_message
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,9 +26,9 @@ class User < ApplicationRecord
         return steam_url_error_message unless valid_steamID?
       elsif id_url?
         extrapolate_steamID
-        return steam_url_error_message unless valid_steamID?
+        errors.add(:steam_url, 'Invalid Steam Profile URL') unless valid_steamID?
       else
-        return steam_url_error_message
+        errors.add(:steam_url, 'Invalid Steam Profile URL')
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,34 +16,36 @@ class User < ApplicationRecord
   private 
 
   def correct_steam_url
-    if !steam_url.nil?
-      vanity_or_steamID_url
-    end
     if !(self.steam_url.nil?) && self.steam_id.nil?
-      if valid_steamID?
-        self.steam_id = extrapolate_steamID
+
+      if vanity_url?
+        extrapolate_steam_vanity
+        convert_steam_vanity_to_steamID
+      elsif id_url?
+        extrapolate_steamID if valid_steamID?
       else
-        errors.add(:steam_url, "Must be proper format")
+        errors.add(:steam_url, 'Must be proper format')
       end
     end
   end
-  
-  def vanity_or_steamID_url
+
+  def parsed_steam_url
     parsed_steam_url = self.steam_url.split('/')
-    if parsed_steam_url[3] == 'id'
-      extrapolate_steam_vanity
-    elsif parsed_steam_url[3] == 'profile'
-      extrapolate_steamID
-    end
+  end
+
+  def vanity_url?
+    parsed_steam_url[3] == 'id'
+  end
+  def id_url?
+    parsed_steam_url[3] == 'profile'
   end
     
   def extrapolate_steamID
-    self.steam_id = parse_steam_url[4]
+    self.steam_id = parsed_steam_url[4]
   end
 
   def extrapolate_steam_vanity
-    self.steam_vanity = parse_steam_url[4]
-    convert_steam_vanity_to_steamID
+    self.steam_vanity = parsed_steam_url[4]
   end
 
   def convert_steam_vanity_to_steamID

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe User, type: :model do
 
     it 'should raise an error if invalid steam url' do
       invalid_user.save
-      expect(invalid_user.errors.errors.first.type).to eq("Must be proper format")
+      expect(invalid_user.errors.errors.first.type).to eq("Invalid Steam Profile URL")
     end
 
     it 'should raise an error if invalid steam url v2' do
@@ -64,7 +64,7 @@ RSpec.describe User, type: :model do
         user.save!
       rescue => error 
       end
-      expect(error.message).to eq("Validation failed: Steam url Must be proper format")
+      expect(error.message).to eq("Validation failed: Steam url Invalid Steam Profile URL")
     end
 
     it 'should update the steam_vanity if given a vanity steam url' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe User, type: :model do
 
   end
 
-  context '#update_steamID' do
+  describe 'correct_steam_url_validations' do
     let(:valid_user){User.new(username: 'test user', email: 'Email@email.com', password: '123456', steam_url: 'https://steamcommunity.com/profiles/76561198068892037/')}
     let(:invalid_user){User.new(username: 'test user', email: 'Email@email.com', password: '123456', steam_url: 'https://steamcommunity.com/profiles/737/')}
     before :each do
@@ -30,6 +30,7 @@ RSpec.describe User, type: :model do
     end
     it 'should update the steamID if nil and if given a new steam_url' do
       valid_user.save
+      
       expect(valid_user.steam_id).to eq('76561198068892037')
     end
 
@@ -65,6 +66,21 @@ RSpec.describe User, type: :model do
       end
       expect(error.message).to eq("Validation failed: Steam url Must be proper format")
     end
+
+    it 'should update the steam_vanity if given a vanity steam url' do
+      valid_user.steam_url = 'https://steamcommunity.com/id/FifthSurprise/'
+      valid_user.save
+      expect(valid_user.steam_vanity).to eq('FifthSurprise')
+    end
+
+    it 'should not update the steam_vanity if given a vanity steam url while already having a steam vanity id' do
+      valid_user.steam_vanity = 'SampleName'
+      valid_user.save
+      valid_user.steam_url = 'https://steamcommunity.com/id/FifthSurprise/'
+      valid_user.save
+      expect(valid_user.steam_vanity).to eq('SampleName')
+    end
+
   end
 
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe User, type: :model do
       user = User.new(username: 'test user', email: 'Email@email.com', password: '123456')
       expect(user.save).to eq(true)
     end
-
   end
 
   describe 'correct_steam_url_validations' do
@@ -73,7 +72,7 @@ RSpec.describe User, type: :model do
         invalid_user.save
         expect(invalid_user.errors.errors.length).to eq(1)
       end
-      
+
       it 'should raise an error if invalid steam url' do
         invalid_user.save
         expect(invalid_user.errors.errors.first.type).to eq("Invalid Steam Profile URL")
@@ -86,7 +85,17 @@ RSpec.describe User, type: :model do
         end
         expect(error.message).to eq("Validation failed: Steam url Invalid Steam Profile URL")
       end
+
+      it 'should raise an error if a non steam URL is given' do
+        invalid_user.steam_url = 'BadURL.com'
+        begin
+          invalid_user.save!
+        rescue => error
+        end
+        expect(error.message).to eq("Validation failed: Steam url Invalid Steam Profile URL")
+      end
+
     end
   end
-
 end
+

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,65 +22,71 @@ RSpec.describe User, type: :model do
   end
 
   describe 'correct_steam_url_validations' do
-    let(:valid_user){User.new(username: 'test user', email: 'Email@email.com', password: '123456', steam_url: 'https://steamcommunity.com/profiles/76561198068892037/')}
-    let(:invalid_user){User.new(username: 'test user', email: 'Email@email.com', password: '123456', steam_url: 'https://steamcommunity.com/profiles/737/')}
-    before :each do
-      allow(valid_user).to receive(:valid_steamID?).and_return true
-      allow(invalid_user).to receive(:valid_steamID?).and_return false
-    end
-    it 'should update the steamID if nil and if given a new steam_url' do
-      valid_user.save
-      
-      expect(valid_user.steam_id).to eq('76561198068892037')
-    end
 
-    it 'should not update the steamID if a steamID already exists and if given a new steam_url' do
-      valid_user.steam_id = '123456'
-      valid_user.save
-      expect(valid_user.steam_id).to eq('123456')
-    end
-
-    it 'should not update the steamID if given a new steam_url when it has one already' do
-      allow(valid_user).to receive(:valid_steamID?).and_return true
-      valid_user.save
-      valid_user.steam_url = 'https://steamcommunity.com/profiles/123456/'
-      valid_user.save
-      expect(valid_user.steam_id).to eq('76561198068892037')
-    end
-
-    it 'should raise an error if invalid steam url' do
-      invalid_user.save
-      expect(invalid_user.errors.errors.length).to eq(1)
-    end
-
-    it 'should raise an error if invalid steam url' do
-      invalid_user.save
-      expect(invalid_user.errors.errors.first.type).to eq("Invalid Steam Profile URL")
-    end
-
-    it 'should raise an error if invalid steam url v2' do
-      user = User.new(username: 'test user', email: 'Email@email.com', password: '123456', steam_url: 'https://steamcommunity.com/profiles/737/')
-      begin
-        user.save!
-      rescue => error 
+    context 'proper steam_url' do
+      let(:valid_user){User.new(username: 'test user', email: 'Email@email.com', password: '123456', steam_url: 'https://steamcommunity.com/profiles/76561198068892037/')}
+      before :each do
+        allow(valid_user).to receive(:valid_steamID?).and_return true
       end
-      expect(error.message).to eq("Validation failed: Steam url Invalid Steam Profile URL")
+
+      it 'should update the steamID if nil and if given a new steam_url' do
+        valid_user.save
+        expect(valid_user.steam_id).to eq('76561198068892037')
+      end
+
+      it 'should not update the steamID if a steamID already exists and if given a new steam_url' do
+        valid_user.steam_id = '123456'
+        valid_user.save
+        expect(valid_user.steam_id).to eq('123456')
+      end
+
+      it 'should not update the steamID if given a new steam_url when it has a url already' do
+        allow(valid_user).to receive(:valid_steamID?).and_return true
+        valid_user.save
+        valid_user.steam_url = 'https://steamcommunity.com/profiles/123456/'
+        valid_user.save
+        expect(valid_user.steam_id).to eq('76561198068892037')
+      end
+
+      it 'should update the steam_vanity if given a vanity steam url' do
+        valid_user.steam_url = 'https://steamcommunity.com/id/FifthSurprise/'
+        valid_user.save
+        expect(valid_user.steam_vanity).to eq('FifthSurprise')
+      end
+
+      it 'should not update the steam_vanity if given a vanity steam url while already having a steam vanity id' do
+        valid_user.steam_vanity = 'SampleName'
+        valid_user.save
+        valid_user.steam_url = 'https://steamcommunity.com/id/FifthSurprise/'
+        valid_user.save
+        expect(valid_user.steam_vanity).to eq('SampleName')
+      end
     end
 
-    it 'should update the steam_vanity if given a vanity steam url' do
-      valid_user.steam_url = 'https://steamcommunity.com/id/FifthSurprise/'
-      valid_user.save
-      expect(valid_user.steam_vanity).to eq('FifthSurprise')
-    end
+    context 'improper steam URL' do
+      let(:invalid_user){User.new(username: 'test user', email: 'Email@email.com', password: '123456', steam_url: 'https://steamcommunity.com/profiles/737/')}
+      before :each do
+        allow(invalid_user).to receive(:valid_steamID?).and_return false
+      end
 
-    it 'should not update the steam_vanity if given a vanity steam url while already having a steam vanity id' do
-      valid_user.steam_vanity = 'SampleName'
-      valid_user.save
-      valid_user.steam_url = 'https://steamcommunity.com/id/FifthSurprise/'
-      valid_user.save
-      expect(valid_user.steam_vanity).to eq('SampleName')
-    end
+      it 'should raise an error if invalid steam url' do
+        invalid_user.save
+        expect(invalid_user.errors.errors.length).to eq(1)
+      end
+      
+      it 'should raise an error if invalid steam url' do
+        invalid_user.save
+        expect(invalid_user.errors.errors.first.type).to eq("Invalid Steam Profile URL")
+      end
 
+      it 'should raise an error if invalid steam url v2' do
+        begin
+          invalid_user.save!
+        rescue => error 
+        end
+        expect(error.message).to eq("Validation failed: Steam url Invalid Steam Profile URL")
+      end
+    end
   end
 
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -28,6 +28,16 @@ RSpec.describe User, type: :model do
         allow(valid_user).to receive(:valid_steamID?).and_return true
       end
 
+      it 'should be able to save if a proper id url is given' do
+        expect(valid_user.save).to be(true)
+      end
+
+      
+      it 'should be able to save if a proper vanity url is given' do
+        valid_user.steam_url = 'https://steamcommunity.com/profiles/123456/'
+        expect(valid_user.save).to be(true)
+      end
+
       it 'should update the steamID if nil and if given a new steam_url' do
         valid_user.save
         expect(valid_user.steam_id).to eq('76561198068892037')
@@ -103,15 +113,15 @@ RSpec.describe User, type: :model do
         expect(error.message).to eq("Validation failed: Steam url Invalid Steam Profile URL")
       end
 
-      it 'should not update steam_vanity if an improper url is given' do
+      it 'should not save if an improper id url is given' do
         expect(invalid_user.save).to be(false)
       end
    
-      it 'should not save if an improper url is given' do
+      it 'should not save if an improper vanity url is given' do
         invalid_user.steam_url = 'https://steamcommunity.com/profiles/dqwd654as28/'
         expect(invalid_user.save).to be(false)
       end
-      
+
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -53,6 +53,13 @@ RSpec.describe User, type: :model do
         expect(valid_user.steam_vanity).to eq('FifthSurprise')
       end
 
+      it 'should update the steam_id if given a vanity steam url' do
+        valid_user.steam_url = 'https://steamcommunity.com/id/FifthSurprise/'
+        valid_user.save
+        
+        expect(valid_user.steam_id).to eq('76561197985548237')
+      end
+
       it 'should not update the steam_vanity if given a vanity steam url while already having a steam vanity id' do
         valid_user.steam_vanity = 'SampleName'
         valid_user.save

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe User, type: :model do
         expect(invalid_user.errors.errors.length).to eq(1)
       end
 
+
       it 'should raise an error if invalid steam url' do
         invalid_user.save
         expect(invalid_user.errors.errors.first.type).to eq("Invalid Steam Profile URL")
@@ -102,6 +103,15 @@ RSpec.describe User, type: :model do
         expect(error.message).to eq("Validation failed: Steam url Invalid Steam Profile URL")
       end
 
+      it 'should not update steam_vanity if an improper url is given' do
+        expect(invalid_user.save).to be(false)
+      end
+   
+      it 'should not save if an improper url is given' do
+        invalid_user.steam_url = 'https://steamcommunity.com/profiles/dqwd654as28/'
+        expect(invalid_user.save).to be(false)
+      end
+      
     end
   end
 end


### PR DESCRIPTION
Updated the validation to check if the given steam url link is a vanity url or a regular steam id link. If it is a valid link it will update the user's steam_vanity, steam_id and steam_url. Also added test and tried to subdivide them hopefully done properly. 

I'm not sure i like the correct_steam_url method. It has a bunch of nested If statements but I'm not sure how to avoid that? Any feedback is appreciated